### PR TITLE
Updates for test kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,12 +1,17 @@
 ---
 driver:
-  name: vagrant
+  name: docker
+  use_sudo: false
+  privileged: true
+  username: kitchen
+  provision_command: mkdir -p /run/sshd
 
 provisioner:
   name: chef_zero
 
 platforms:
   - name: ubuntu-12.04
+  - name: ubuntu-18.04
 
 suites:
   - name: scprv4

--- a/Berksfile
+++ b/Berksfile
@@ -7,8 +7,8 @@ cookbook "lifeguard"
 cookbook "scpr-consul"
 cookbook "scpr-tools"
 
-cookbook 'scpr-apps-test', path:"./test/cookbook"
+#cookbook 'scpr-apps-test', path:"./test/cookbook"
 
-cookbook "libarchive", path:"../forks/libarchive-cookbook"
+cookbook "libarchive"
 
 metadata

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 TODO: Enter the cookbook description here.
 
+## Testing
+
+Test with (Test Kitchen)[https://kitchen.ci/], e.g.,
+
+```
+kitchen converge
+kitchen verify
+```
+
+You will need Test Kitchen and Docker installed.


### PR DESCRIPTION
This switches to the Docker provisioner for Test Kitchen, and will converge both the Ubuntu 12 and 18 platforms for these roles.

This should be safe unless these tests are already running in CI somewhere.