### PR TITLE
Pin libarchive directly to 1.0.0

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -9,6 +9,6 @@ cookbook "scpr-tools"
 
 #cookbook 'scpr-apps-test', path:"./test/cookbook"
 
-cookbook "libarchive"
+cookbook 'libarchive', '= 1.0.0'
 
 metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license          'All rights reserved'
 description      'Installs/Configures scpr-apps'
 long_description 'Installs/Configures scpr-apps'
 supports         'ubuntu'
-version          '0.2.26'
+version          '0.2.28'
 
 depends "apt"
 depends "nginx_passenger", "~> 0.5.5"


### PR DESCRIPTION
See, e.g.,
https://github.com/chef-cookbooks/elixir/issues/8