### PR TITLE
Remove scprv4 workers

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license          'All rights reserved'
 description      'Installs/Configures scpr-apps'
 long_description 'Installs/Configures scpr-apps'
 supports         'ubuntu'
-version          '0.2.33'
+version          '0.2.34'
 
 depends 'apt'
 depends 'nginx_passenger', '~> 0.5.5'


### PR DESCRIPTION
Does this remove the resque background workers from running? I'm talking about the ones that show up when you `ps aux` in `sharedworker002`. Examples:

```
999      10336  0.0  3.1 514368 127724 ?       Sl   May29  25:55 ruby2.1 /scpr/scprv4_production/shared/bundle/ruby/2.1.0/bin/rake asset_sync
999      10725  0.0  3.0 514352 125024 ?       Sl   May29  22:21 ruby2.1 /scpr/scprv4_production/shared/bundle/ruby/2.1.0/bin/rake asset_sync
999      11377  0.0  2.7 510832 112708 ?       Sl   May29  20:30 ruby2.1 /scpr/scprv4_production/shared/bundle/ruby/2.1.0/bin/rake asset_sync
999      11394  0.0  2.8 514348 115976 ?       Sl   May29  21:08 ruby2.1 /scpr/scprv4_production/shared/bundle/ruby/2.1.0/bin/rake asset_sync
999      11956  0.0  2.7 510796 110812 ?       Sl   May29  20:45 ruby2.1 /scpr/scprv4_production/shared/bundle/ruby/2.1.0/bin/rake asset_sync
999      12051  0.0  2.7 514376 111876 ?       Sl   May29  22:57 ruby2.1 /scpr/scprv4_production/shared/bundle/ruby/2.1.0/bin/rake asset_sync
999      12082  0.0  2.7 514392 110664 ?       Sl   May29  20:21 ruby2.1 /scpr/scprv4_production/shared/bundle/ruby/2.1.0/bin/rake asset_sync
```